### PR TITLE
add KRef API

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -141,3 +141,17 @@ func Exitf(format string, args ...interface{}) {
 	level.Error(logger).Log("func", "Exitf", "msg", fmt.Sprintf(format, args...))
 	os.Exit(1)
 }
+
+// ObjectRef references a kubernetes object
+type ObjectRef struct {
+	Name      string `json:"name"`
+	Namespace string `json:"namespace,omitempty"`
+}
+
+// KRef returns ObjectRef from name and namespace
+func KRef(namespace, name string) ObjectRef {
+	return ObjectRef{
+		Name:      name,
+		Namespace: namespace,
+	}
+}


### PR DESCRIPTION
Currently the Grafana Agent depends on `k8s.io/client-go` v0.21.0 which depends on `k8s.io/klog/v2` v2.8.0. 

The client-go code makes a call to this `KRef` API, which this PR adds, allowing us to continue using this package.
https://github.com/kubernetes/client-go/blob/v0.21.0/tools/record/event.go#L291

Let me know if adding this makes sense or if I should be taking another approach here. Thanks!