### PR TITLE
Adds ErrorS function

### DIFF
--- a/klog.go
+++ b/klog.go
@@ -124,6 +124,10 @@ func Errorf(format string, args ...interface{}) {
 	level.Error(logger).Log("func", "Errorf", "msg", fmt.Sprintf(format, args...))
 }
 
+func ErrorS(err error, msg string, keysAndValues ...interface{}) {
+	level.Error(logger).Log("func", "ErrorS", "msg", msg, "err", err, keysAndValues)
+}
+
 func Fatal(args ...interface{}) {
 	level.Error(logger).Log("func", "Fatal", "msg", fmt.Sprint(args...))
 	os.Exit(255)


### PR DESCRIPTION
I'm utilizing [retrywatcher from client-go](https://github.com/kubernetes/client-go/blob/master/tools/watch/retrywatcher.go) which depends on the `klog.ErrorS` function [being present](https://github.com/kubernetes/client-go/blob/04ef61f72b7bc5ae6efef4e4dc0001746637fdb3/tools/watch/retrywatcher.go#L130-L136). This PR adds that function and does the delegation to `gokit`.